### PR TITLE
Add "withAlpha" prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uscreentv/v-color",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uscreentv/v-color",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.js",

--- a/src/VColorPicker.vue
+++ b/src/VColorPicker.vue
@@ -27,6 +27,7 @@
           </div>
         </v-ctrl>
         <v-ctrl
+          v-if="withAlpha"
           direction="h"
           :precision="2"
           :throttle="80"
@@ -144,6 +145,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    withAlpha: {
+      type: Boolean,
+      default: true,
+    }
   },
 
   components: {

--- a/src/VColorPopover.vue
+++ b/src/VColorPopover.vue
@@ -5,7 +5,7 @@
     </button>
     <transition :name="currentTransitionName">
       <div v-if="isVisible" class="frame" :class="framePositionClass">
-        <color-picker :value="value" :with-suggestions="withSuggestions" @input="onInput" />
+        <color-picker :value="value" :with-suggestions="withSuggestions" :with-alpha="withAlpha" @input="onInput" />
       </div>
     </transition>
   </div>
@@ -34,6 +34,10 @@ export default {
       default: '#ff0000',
     },
     withSuggestions: {
+      type: Boolean,
+      default: true,
+    },
+    withAlpha: {
       type: Boolean,
       default: true,
     },


### PR DESCRIPTION
Add the "withAlpha" prop to control if the alpha channel track should be displayed.
I want to use it to hide the alpha channel in the Primary color picker.

![image](https://user-images.githubusercontent.com/1245209/118103711-defc7580-b3e2-11eb-931c-cdf85bf1f648.png)
