### PR TITLE
Add inputDebounceMs prop to configure debounce latency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uscreentv/v-color",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.js",

--- a/src/VColorPicker.vue
+++ b/src/VColorPicker.vue
@@ -148,7 +148,11 @@ export default {
     withAlpha: {
       type: Boolean,
       default: true,
-    }
+    },
+    inputDebounceMs: {
+      type: Number,
+      default: 900,
+    },
   },
 
   components: {
@@ -437,7 +441,7 @@ export default {
   },
 
   created () {
-    this.handleInput = debounce(this.handleInput.bind(this), 250)
+    this.handleInput = debounce(this.handleInput.bind(this), this.inputDebounceMs)
     this.emitChange = debounce(this.emitChange.bind(this), 250)
 
     this.updateColorModel()


### PR DESCRIPTION
closes https://github.com/Uscreen-video/issues/issues/441

# tech description
Adds a prop to configure debounce latency time. Default 900 ms should be enough

# before
https://www.loom.com/share/9838337293b744ef8e182f39de2dd72c