### PR TITLE
Reset alpha value if the alpha-bar is not visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uscreentv/v-color",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.js",

--- a/src/VColorPicker.vue
+++ b/src/VColorPicker.vue
@@ -294,13 +294,14 @@ export default {
       const rgba = parse2rgb(val)
       const alpha = rgba[3] == null ? 1 : rgba[3]
       const [hue, saturation, value] = rgb2hsv(rgba)
+      const { withAlpha } = this
 
       // format of alpha: `.2f`
       // according to Chrome DevTool
       const _alpha = parseFloat(alpha.toFixed(2))
 
       return {
-        alpha: _alpha,
+        alpha: withAlpha ? _alpha : 1,
         hue: hue / 360,
         saturation: {
           x: saturation / 100,


### PR DESCRIPTION
Before deploying this PR: https://github.com/Uscreen-video/uscreen_2/pull/5285 Ivan found that hiding of the alpha channel makes its value fixed forever. If some customer set it to 0.75 then this value will stay forever.

This PR makes sure that if the `with-alpha` prop is not true, then the `alpha` value is always `1`.

How I tested this:
1. Built the `v-color` package locally.
2. Imported the `VColorPopover` component in the `GlobalCustomization.vue` component not from '@uscreentv/v-color' but from my locally built `v-color/dist/index.js`
3. Set `with-alpha="true"`. Saved the primary color with transparency. Changed to `with-alpha="false"`. Set a new primary color, checked that the color is not transparent, alpha is 1.